### PR TITLE
Remove unused width marker and switch to https

### DIFF
--- a/cm3-wrapup.md
+++ b/cm3-wrapup.md
@@ -16,9 +16,9 @@ Schémas présentés :
 
 Quelques schémas utilisés :
 
-![Diffie-Hellman](http://www.practicalnetworking.net/wp-content/uploads/2015/11/dh-revised-1024x751.png "Diffie-Hellman"){width=40%}
+![Diffie-Hellman](http://www.practicalnetworking.net/wp-content/uploads/2015/11/dh-revised-1024x751.png "Diffie-Hellman")
 
-![TLS](http://rebecca.meritz.com/ggm15/handshake.png "TLS")
+![TLS](https://rebecca.meritz.com/ggm15/handshake.png "TLS")
 
 ![Kerberos](https://upload.wikimedia.org/wikipedia/commons/a/a6/Kerberos-simple.svg "Kerberos")
 

--- a/cm3-wrapup.md
+++ b/cm3-wrapup.md
@@ -16,7 +16,7 @@ Schémas présentés :
 
 Quelques schémas utilisés :
 
-![Diffie-Hellman](http://www.practicalnetworking.net/wp-content/uploads/2015/11/dh-revised-1024x751.png "Diffie-Hellman")
+![Diffie-Hellman](http://www.practicalnetworking.net/wp-content/uploads/2015/11/dh-revised-1024x751.png "Diffie-Hellman"){width=40%}
 
 ![TLS](https://rebecca.meritz.com/ggm15/handshake.png "TLS")
 


### PR DESCRIPTION
The width marker doesn't work as expected and was shown as plain text on the rendered page.
The TLS image is now served via HTTPS ¯\\\_(ツ)\_/¯